### PR TITLE
fix: disable cursor-glow on mobile devices

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,15 +22,16 @@ import "../styles/global.css";
     <div class="blob blob2"></div>
     <div class="blob blob3"></div>
     <script>
-      const glow = document.createElement('div');
-      glow.classList.add('cursor-glow');
-      document.body.appendChild(glow);
+      if (!('ontouchstart' in window)) {
+  const glow = document.createElement("div");
+  glow.classList.add("cursor-glow");
+  document.body.appendChild(glow);
 
-      document.addEventListener('mousemove', e => {
-        glow.style.left = e.clientX + 'px';
-        glow.style.top = e.clientY + 'px';
-      });
-
+  document.addEventListener("mousemove", (e) => {
+    glow.style.left = `${e.clientX}px`;
+    glow.style.top = `${e.clientY}px`;
+  });
+}
     </script>
   </body>
 </html>


### PR DESCRIPTION
Added touch check to prevent cursor-glow from loading on mobile.
Now this effect will be disabled on phones, tablets, and all touch screen devices — which saves resources and improves UX on mobile.